### PR TITLE
Adds assume nonnull tags to RCTWWKWebView.h to remove warnings

### DIFF
--- a/React/Views/RCTWKWebView.h
+++ b/React/Views/RCTWKWebView.h
@@ -9,6 +9,8 @@
 #import <React/RCTDefines.h>
 #import <WebKit/WebKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class RCTWKWebView;
 
 @protocol RCTWKWebViewDelegate <NSObject>
@@ -45,3 +47,5 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 - (void)stopLoading;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Summary

The CNN iOS app utilizes https://github.com/turnerlabs/react-native/tree/v0.59.10/ in order to provide React Native to the app. There are a handful of warnings being generated by this tag that we wish to resolve. We are using this `support/cnn-ios-7` branch to implement small fixes like this, and this is the first PR into that branch.

## Changelog

[iOS] [Fixed] - Adds `NS_ASSUME_NONNULL_BEGIN` to the file `RCTWKWebView.h` to remove several nullability warnings. Code behavior should not actually be affected.

## Test Plan

Build and run the project, after it is pointing to this branch in its `package.json` file. See normal behavior.
